### PR TITLE
[Feat] Adding support for Unions and Literals

### DIFF
--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -15,12 +15,12 @@
  */
 import ts from 'typescript';
 
-import {DEFAULT_ARRAY_RANGE, FIXED_ARRAY_COUNT} from '../../lib/constants';
-import {defaultTypeToMock} from '../../lib/default-type-to-mock';
-import {fake} from '../../lib/fake';
-import {randomRange} from '../../lib/random-range';
-import {smartProps} from '../../lib/smart-props';
-import {stringify} from '../../lib/stringify';
+import { DEFAULT_ARRAY_RANGE, FIXED_ARRAY_COUNT } from '../../lib/constants';
+import { defaultTypeToMock, SupportedTypes } from '../../lib/default-type-to-mock';
+import { fake } from '../../lib/fake';
+import { randomRange } from '../../lib/random-range';
+import { smartProps } from '../../lib/smart-props';
+import { stringify } from '../../lib/stringify';
 
 /**
  * Intermock general options
@@ -46,7 +46,7 @@ export interface Options {
   isOptionalAlwaysEnabled?: boolean;
 }
 
-type OutputType = 'object'|'json'|'string';
+type OutputType = 'object' | 'json' | 'string';
 type SupportedLanguage = 'typescript';
 
 interface JSDoc {
@@ -75,8 +75,8 @@ type Types = Record<string, TypeCacheRecord>;
  * @param mockType Optional specification of what Faker type to use
  */
 function generatePrimitive(
-    property: string, syntaxType: ts.SyntaxKind, options: Options,
-    mockType?: string) {
+  property: string, syntaxType: ts.SyntaxKind, options: Options,
+  mockType?: string) {
   const smartMockType = smartProps[property];
   const isFixedMode = options.isFixedMode ? options.isFixedMode : false;
 
@@ -85,6 +85,9 @@ function generatePrimitive(
   } else if (smartMockType) {
     return fake(smartMockType, options.isFixedMode);
   } else {
+    if (!defaultTypeToMock[syntaxType]) {
+      throw Error(`Unsupported Primitive type ${syntaxType}`);
+    }
     return defaultTypeToMock[syntaxType](isFixedMode);
   }
 }
@@ -97,9 +100,10 @@ function generatePrimitive(
  * @param options Intermock general options object
  */
 function isQuestionToken(
-    questionToken: ts.Token<ts.SyntaxKind.QuestionToken>|undefined,
-    options: Options) {
-  if (questionToken) {
+  questionToken: ts.Token<ts.SyntaxKind.QuestionToken> | undefined,
+  isUnionWithNull: boolean,
+  options: Options) {
+  if (questionToken || isUnionWithNull) {
     if (options.isFixedMode && !options.isOptionalAlwaysEnabled) {
       return true;
     }
@@ -122,8 +126,8 @@ function isQuestionToken(
  * @param options Intermock general options object
  */
 function processGenericPropertyType(
-    output: Output, property: string, kind: ts.SyntaxKind, mockType: string,
-    options: Options) {
+  output: Output, property: string, kind: ts.SyntaxKind, mockType: string,
+  options: Options) {
   const mock = generatePrimitive(property, kind, options, mockType);
   output[property] = mock;
 }
@@ -141,8 +145,8 @@ function processGenericPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processFunctionPropertyType(
-    node: ts.PropertySignature, output: Output, property: string,
-    sourceFile: ts.SourceFile, options: Options, types: Types) {
+  node: ts.PropertySignature, output: Output, property: string,
+  sourceFile: ts.SourceFile, options: Options, types: Types) {
   // TODO process args from parameters of function
   const args = '';
   let body = '';
@@ -154,15 +158,15 @@ function processFunctionPropertyType(
     case ts.SyntaxKind.TypeReference:
       const tempBody: Record<string, {}> = {};
       processPropertyTypeReference(
-          node, tempBody, 'body',
-          ((returnType as ts.TypeReferenceNode).typeName as ts.Identifier).text,
-          returnType.kind, sourceFile, options, types);
+        node, tempBody, 'body',
+        ((returnType as ts.TypeReferenceNode).typeName as ts.Identifier).text,
+        returnType.kind, sourceFile, options, types);
 
       body = `return ${stringify(tempBody['body'])}`;
       break;
     default:
       body = `return ${
-          JSON.stringify(generatePrimitive('', returnType.kind, options))}`;
+        JSON.stringify(generatePrimitive('', returnType.kind, options))}`;
       break;
   }
 
@@ -183,14 +187,14 @@ function processFunctionPropertyType(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processPropertyTypeReference(
-    node: ts.PropertySignature, output: Output, property: string,
-    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-    options: Options, types: Types) {
+  node: ts.PropertySignature, output: Output, property: string,
+  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+  options: Options, types: Types) {
   let normalizedTypeName;
 
   if (typeName.startsWith('Array<') || typeName.startsWith('IterableArray<')) {
     normalizedTypeName =
-        typeName.replace(/(Array|IterableArray)\</, '').replace('>', '');
+      typeName.replace(/(Array|IterableArray)\</, '').replace('>', '');
   } else {
     normalizedTypeName = typeName;
   }
@@ -198,15 +202,15 @@ function processPropertyTypeReference(
   // TODO: Handle other generics
   if (normalizedTypeName !== typeName) {
     processArrayPropertyType(
-        node, output, property, normalizedTypeName, kind, sourceFile, options,
-        types);
+      node, output, property, normalizedTypeName, kind, sourceFile, options,
+      types);
     return;
   }
 
   if (!types[normalizedTypeName]) {
     throw new Error(`Type '${
-        normalizedTypeName}' is not specified in the provided files but is required for property: '${
-        property}'. Please include it.`);
+      normalizedTypeName}' is not specified in the provided files but is required for property: '${
+      property}'. Please include it.`);
   }
 
   switch ((types[normalizedTypeName] as TypeCacheRecord).kind) {
@@ -215,11 +219,11 @@ function processPropertyTypeReference(
       break;
     default:
       if ((types[normalizedTypeName] as TypeCacheRecord).kind !==
-          (types[normalizedTypeName] as TypeCacheRecord).aliasedTo) {
+        (types[normalizedTypeName] as TypeCacheRecord).aliasedTo) {
         const alias = (types[normalizedTypeName] as TypeCacheRecord).aliasedTo;
         const isPrimitiveType = alias === ts.SyntaxKind.StringKeyword ||
-            alias === ts.SyntaxKind.NumberKeyword ||
-            alias === ts.SyntaxKind.BooleanKeyword;
+          alias === ts.SyntaxKind.NumberKeyword ||
+          alias === ts.SyntaxKind.BooleanKeyword;
 
         if (isPrimitiveType) {
           output[property] = generatePrimitive(property, alias, options, '');
@@ -245,8 +249,8 @@ function processPropertyTypeReference(
  * @param options Intermock general options object
  */
 function processJsDocs(
-    node: ts.PropertySignature, output: Output, property: string,
-    jsDocs: JSDoc[], options: Options) {
+  node: ts.PropertySignature, output: Output, property: string,
+  jsDocs: JSDoc[], options: Options) {
   // TODO handle case where we get multiple mock JSDocs or a JSDoc like
   // mockRange for an array. In essence, we are only dealing with
   // primitives now
@@ -290,40 +294,91 @@ function processJsDocs(
  * @param types Top-level types of interfaces/aliases etc.
  */
 function processArrayPropertyType(
-    node: ts.PropertySignature, output: Output, property: string,
-    typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
-    options: Options, types: Types) {
+  node: ts.PropertySignature, output: Output, property: string,
+  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+  options: Options, types: Types) {
   typeName = typeName.replace('[', '').replace(']', '');
   output[property] = [];
 
-  if ((node.type as ts.ArrayTypeNode).elementType) {
+  if (node.type && (node.type as ts.ArrayTypeNode).elementType) {
     kind = (node.type as ts.ArrayTypeNode).elementType.kind;
+  } else if ((node as unknown as ts.ArrayTypeNode).elementType) {
+    kind = (node as unknown as ts.ArrayTypeNode).elementType.kind;
   }
 
+
   const isPrimitiveType = kind === ts.SyntaxKind.StringKeyword ||
-      kind === ts.SyntaxKind.BooleanKeyword ||
-      kind === ts.SyntaxKind.NumberKeyword;
+    kind === ts.SyntaxKind.BooleanKeyword ||
+    kind === ts.SyntaxKind.NumberKeyword;
 
   const arrayRange = options.isFixedMode ?
-      FIXED_ARRAY_COUNT :
-      randomRange(DEFAULT_ARRAY_RANGE[0], DEFAULT_ARRAY_RANGE[1]);
+    FIXED_ARRAY_COUNT :
+    randomRange(DEFAULT_ARRAY_RANGE[0], DEFAULT_ARRAY_RANGE[1]);
 
   for (let i = 0; i < arrayRange; i++) {
     if (isPrimitiveType) {
       (output[property] as Array<{}>)[i] =
-          generatePrimitive(property, kind, options, '');
+        generatePrimitive(property, kind, options, '');
     } else {
       (output[property] as Array<{}>).push({});
       processFile(
-          sourceFile, (output[property] as Array<{}>)[i], options, types,
-          typeName);
+        sourceFile, (output[property] as Array<{}>)[i], options, types,
+        typeName);
     }
+  }
+}
+
+/**
+ * Process an array definition.
+ *
+ * @param node Node being processed
+ * @param output The object outputted by Intermock after all types are mocked
+ * @param property Output property to write to
+ * @param typeName Type name of property
+ * @param kind TS data type of property type
+ * @param sourceFile TypeScript AST object compiled from file data
+ * @param options Intermock general options object
+ * @param types Top-level types of interfaces/aliases etc.
+ */
+function processUnionPropertyType(
+  node: ts.PropertySignature, output: Output, property: string,
+  typeName: string, kind: ts.SyntaxKind, sourceFile: ts.SourceFile,
+  options: Options, types: Types) {
+
+  // @ts-ignore
+  const unionNodes = node ? node.type.types.map((type: ts.Node) => type) as ts.SyntaxKind[] : [];
+  // @ts-ignore
+  const supportedType = unionNodes.find((type: ts.Node) => Object.values(SupportedTypes).includes(type.kind))
+  if (supportedType) {
+    output[property] = generatePrimitive(property, supportedType.kind, options, '');
+    return;
+  } else {
+    // @ts-ignore
+    const typeReferenceNode = unionNodes.find((node: ts.Node) => node.kind === ts.SyntaxKind.TypeReference);
+    if (typeReferenceNode) {
+      processPropertyTypeReference(typeReferenceNode, output, property, typeReferenceNode.typeName.text, typeReferenceNode.kind, sourceFile, options, types);
+      return;
+    }
+    // @ts-ignore
+    const arrayNode = unionNodes.find((node: ts.Node) => node.kind === ts.SyntaxKind.ArrayType);
+    if (arrayNode) {
+      processArrayPropertyType(arrayNode, output, property, `[${arrayNode.elementType.typeName.text}]`, arrayNode.kind, sourceFile, options, types);
+      return;
+    }
+    // @ts-ignore
+    const functionNode = unionNodes.find((node: ts.Node) => node.kind === ts.SyntaxKind.FunctionType);
+    if (functionNode) {
+      processFunctionPropertyType(functionNode, output, property, sourceFile, options, types);
+      return;
+    }
+
+    throw Error(`Unsupported Union option type ${(node as any).property}: ${node && (node as any).typename}`);
   }
 }
 
 function isAnyJsDocs(jsDocs: JSDoc[]) {
   if (jsDocs.length > 0 && jsDocs[0].comment &&
-      jsDocs[0].comment.includes('!mockType')) {
+    jsDocs[0].comment.includes('!mockType')) {
     return true;
   }
 
@@ -340,8 +395,8 @@ function isAnyJsDocs(jsDocs: JSDoc[]) {
  * @param types Top-level types of interfaces/aliases etc.
  */
 function traverseInterfaceMembers(
-    node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
-    types: Types) {
+  node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
+  types: Types) {
   if (node.kind !== ts.SyntaxKind.PropertySignature) {
     return;
   }
@@ -353,13 +408,20 @@ function traverseInterfaceMembers(
       jsDocs = (node as NodeWithDocs).jsDoc;
     }
 
+    let isUnionWithNull = false;
+
     const property = node.name.getText();
     const questionToken = node.questionToken;
+    const isUnion = node.type && node.type.kind === ts.SyntaxKind.UnionType;
+
+    if (isUnion) {
+      isUnionWithNull = !!(node.type as ts.UnionTypeNode).types.map(type => type.kind).some(kind => kind === ts.SyntaxKind.NullKeyword)
+    }
 
     let typeName = '';
     let kind;
 
-    if (isQuestionToken(questionToken, options)) {
+    if (isQuestionToken(questionToken, isUnionWithNull, options)) {
       return;
     }
 
@@ -376,21 +438,26 @@ function traverseInterfaceMembers(
     switch (kind) {
       case ts.SyntaxKind.TypeReference:
         processPropertyTypeReference(
-            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-            options, types);
+          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+          options, types);
+        break;
+      case ts.SyntaxKind.UnionType:
+        processUnionPropertyType(
+          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+          options, types);
         break;
       case ts.SyntaxKind.ArrayType:
         processArrayPropertyType(
-            node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
-            options, types);
+          node, output, property, typeName, kind as ts.SyntaxKind, sourceFile,
+          options, types);
         break;
       case ts.SyntaxKind.FunctionType:
         processFunctionPropertyType(
-            node, output, property, sourceFile, options, types);
+          node, output, property, sourceFile, options, types);
         break;
       default:
         processGenericPropertyType(
-            output, property, kind as ts.SyntaxKind, '', options);
+          output, property, kind as ts.SyntaxKind, '', options);
         break;
     }
   };
@@ -407,8 +474,8 @@ function traverseInterfaceMembers(
  * @param property Output property to write to
  */
 function setEnum(
-    sourceFile: ts.SourceFile, output: Output, types: Types, typeName: string,
-    property: string) {
+  sourceFile: ts.SourceFile, output: Output, types: Types, typeName: string,
+  property: string) {
   const node: unknown = types[typeName].node;
   if (!node) {
     return;
@@ -426,7 +493,7 @@ function setEnum(
         break;
       case ts.SyntaxKind.StringLiteral:
         output[property] =
-            selectedMember.initializer.getText().replace(/\'/g, '');
+          selectedMember.initializer.getText().replace(/\'/g, '');
         break;
       default:
         break;
@@ -449,8 +516,8 @@ function setEnum(
  * @param path Optional specific path to write to on the output object
  */
 function traverseInterface(
-    node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
-    types: Types, propToTraverse?: string, path?: string) {
+  node: ts.Node, output: Output, sourceFile: ts.SourceFile, options: Options,
+  types: Types, propToTraverse?: string, path?: string) {
   if (path) {
     output[path] = {};
     output = output[path];
@@ -473,16 +540,16 @@ function traverseInterface(
 
         if (!types[extensionType]) {
           throw new Error(`Type '${
-              extensionType}' is not specified in the provided files but is required for interface extension of: '${
-              (node as ts.InterfaceDeclaration)
-                  .name.text}'. Please include it.`);
+            extensionType}' is not specified in the provided files but is required for interface extension of: '${
+            (node as ts.InterfaceDeclaration)
+              .name.text}'. Please include it.`);
         }
 
         const extensionNode = types[extensionType].node;
         let extensionOutput: Output = {};
         traverseInterface(
-            extensionNode, extensionOutput, sourceFile, options, types,
-            propToTraverse, path);
+          extensionNode, extensionOutput, sourceFile, options, types,
+          propToTraverse, path);
 
         extensionOutput = extensionOutput[extensionType];
         extensions.push(extensionOutput);
@@ -500,8 +567,8 @@ function traverseInterface(
   // TODO given a range of interfaces to generate, add to array. If 1
   // then just return an object
   node.forEachChild(
-      child =>
-          traverseInterfaceMembers(child, output, sourceFile, options, types));
+    child =>
+      traverseInterfaceMembers(child, output, sourceFile, options, types));
 }
 
 function isSpecificInterface(name: string, options: Options) {
@@ -527,8 +594,8 @@ function isSpecificInterface(name: string, options: Options) {
  *     interface
  */
 function processFile(
-    sourceFile: ts.SourceFile, output: Output, options: Options, types: Types,
-    propToTraverse?: string) {
+  sourceFile: ts.SourceFile, output: Output, options: Options, types: Types,
+  propToTraverse?: string) {
   const processNode = (node: ts.Node) => {
     switch (node.kind) {
       case ts.SyntaxKind.InterfaceDeclaration:
@@ -544,7 +611,7 @@ function processFile(
         if (propToTraverse) {
           if (p === propToTraverse) {
             traverseInterface(
-                node, output, sourceFile, options, types, propToTraverse);
+              node, output, sourceFile, options, types, propToTraverse);
           }
         } else {
           traverseInterface(node, output, sourceFile, options, types);
@@ -561,11 +628,11 @@ function processFile(
         if (propToTraverse) {
           if (path === propToTraverse) {
             traverseInterface(
-                type, output, sourceFile, options, types, propToTraverse);
+              type, output, sourceFile, options, types, propToTraverse);
           }
         } else {
           traverseInterface(
-              type, output, sourceFile, options, types, undefined, path);
+            type, output, sourceFile, options, types, undefined, path);
         }
         break;
 
@@ -585,11 +652,11 @@ function processFile(
  *
  * @param sourceFile TypeScript AST object compiled from file data
  */
-function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
+function gatherTypes(sourceFile: ts.SourceFile | ts.ModuleBlock) {
   const types: Types = {};
   let modulePrefix = '';
 
-  const processNode = (node: ts.Node|ts.ModuleBlock) => {
+  const processNode = (node: ts.Node | ts.ModuleBlock) => {
     const name = (node as ts.DeclarationStatement).name;
     const text = name ? name.text : '';
 
@@ -612,9 +679,9 @@ function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
     }
 
     if (modulePrefix) {
-      types[`${modulePrefix}.${text}`] = {kind: node.kind, aliasedTo, node};
+      types[`${modulePrefix}.${text}`] = { kind: node.kind, aliasedTo, node };
     }
-    types[text] = {kind: node.kind, aliasedTo, node};
+    types[text] = { kind: node.kind, aliasedTo, node };
 
     ts.forEachChild(node, processNode);
   };
@@ -631,7 +698,7 @@ function gatherTypes(sourceFile: ts.SourceFile|ts.ModuleBlock) {
  * @param output The object outputted by Intermock after all types are mocked
  * @param options Intermock general options object
  */
-function formatOutput(output: Output, options: Options): string|Output {
+function formatOutput(output: Output, options: Options): string | Output {
   switch (options.output) {
     case 'json':
       return JSON.stringify(output);
@@ -664,15 +731,15 @@ export function mock(options: Options) {
 
   fileContents.forEach((f) => {
     types = Object.assign(
-        {}, types,
-        gatherTypes(
-            ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true)));
+      {}, types,
+      gatherTypes(
+        ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true)));
   });
 
   fileContents.forEach((f) => {
     processFile(
-        ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true), output,
-        options, types);
+      ts.createSourceFile(f[0], f[1], ts.ScriptTarget.ES2015, true), output,
+      options, types);
   });
 
   return formatOutput(output, options);

--- a/src/lang/ts/intermock.ts
+++ b/src/lang/ts/intermock.ts
@@ -126,8 +126,21 @@ function isQuestionToken(
  * @param options Intermock general options object
  */
 function processGenericPropertyType(
-  output: Output, property: string, kind: ts.SyntaxKind, mockType: string,
+  node: ts.Node, output: Output, property: string, kind: ts.SyntaxKind, mockType: string,
   options: Options) {
+  // @ts-ignore
+  if (node && node.type && node.type.kind === ts.SyntaxKind.LiteralType) {
+    if ((node as any).type.literal.kind === ts.SyntaxKind.TrueKeyword) {
+      output[property] = true;
+    } else if ((node as any).type.literal.kind === ts.SyntaxKind.FalseKeyword) {
+      output[property] = false;
+    } else if ((node as any).type.literal.kind === ts.SyntaxKind.StringLiteral) {
+      output[property] = (node as any).type.literal.text;
+    } else {
+      output[property] = parseInt((node as any).type.literal.text, 10);
+    }
+    return;
+  }
   const mock = generatePrimitive(property, kind, options, mockType);
   output[property] = mock;
 }
@@ -457,7 +470,7 @@ function traverseInterfaceMembers(
         break;
       default:
         processGenericPropertyType(
-          output, property, kind as ts.SyntaxKind, '', options);
+          node, output, property, kind as ts.SyntaxKind, '', options);
         break;
     }
   };

--- a/src/lib/default-type-to-mock.ts
+++ b/src/lib/default-type-to-mock.ts
@@ -14,18 +14,26 @@
  * limitations under the License.
  */
 import ts from 'typescript';
-import {fake} from './fake';
+import { fake } from './fake';
+
+export enum SupportedTypes {
+  NumberKeyword = ts.SyntaxKind.NumberKeyword,
+  StringKeyword = ts.SyntaxKind.StringKeyword,
+  BooleanKeyword = ts.SyntaxKind.BooleanKeyword,
+  ObjectKeyword = ts.SyntaxKind.ObjectKeyword,
+  AnyKeyword = ts.SyntaxKind.AnyKeyword,
+}
 
 /* tslint:disable */
 export const defaultTypeToMock: {
   [index: number]: (isFixedMode: boolean) => string | number | boolean | object
 } = {
   [ts.SyntaxKind.NumberKeyword]: (isFixedMode = false) =>
-      parseInt(fake('random.number', isFixedMode) as string, 10),
+    parseInt(fake('random.number', isFixedMode) as string, 10),
   [ts.SyntaxKind.StringKeyword]: (isFixedMode = false) =>
-      fake('lorem.text', isFixedMode),
+    fake('lorem.text', isFixedMode),
   [ts.SyntaxKind.BooleanKeyword]: (isFixedMode = false) =>
-      JSON.parse(fake('random.boolean', isFixedMode) as string),
+    JSON.parse(fake('random.boolean', isFixedMode) as string),
   [ts.SyntaxKind.ObjectKeyword]: (isFixedMode = false) => {
     return {}
   },

--- a/test/ts/mock.spec.ts
+++ b/test/ts/mock.spec.ts
@@ -16,30 +16,31 @@
 
 import 'mocha';
 
-import {expect} from 'chai';
+import { expect } from 'chai';
 
-import {mock} from '../../index';
-import {Options} from '../../src/lang/ts/intermock';
-import {readFiles} from '../../src/lib/read-files';
+import { mock } from '../../index';
+import { Options } from '../../src/lang/ts/intermock';
+import { readFiles } from '../../src/lib/read-files';
 
-import {expectedAny} from './test-data/any';
-import {expectedArray1} from './test-data/array';
-import {expectedEnum} from './test-data/enum';
-import {expectedContractor} from './test-data/extension';
-import {expectedFlat} from './test-data/flat';
-import {FunctionInterface} from './test-data/functions';
-import {expectedJson} from './test-data/json';
-import {expectedMockType} from './test-data/mockType';
-import {expectedNamespaced} from './test-data/namespace';
-import {expectedNested} from './test-data/nestedSingle';
-import {expectedOptional1, expectedOptional2} from './test-data/optional';
-import {expectedSpecificInterface} from './test-data/specificInterfaces';
-import {expectedTypeAlias} from './test-data/typeAlias';
+import { expectedAny } from './test-data/any';
+import { expectedArray1 } from './test-data/array';
+import { expectedEnum } from './test-data/enum';
+import { expectedUnion } from './test-data/unions';
+import { expectedContractor } from './test-data/extension';
+import { expectedFlat } from './test-data/flat';
+import { FunctionInterface } from './test-data/functions';
+import { expectedJson } from './test-data/json';
+import { expectedMockType } from './test-data/mockType';
+import { expectedNamespaced } from './test-data/namespace';
+import { expectedNested } from './test-data/nestedSingle';
+import { expectedOptional1, expectedOptional2 } from './test-data/optional';
+import { expectedSpecificInterface } from './test-data/specificInterfaces';
+import { expectedTypeAlias } from './test-data/typeAlias';
 
 async function runTestCase(
-    file: string, outputProp: string, expected: unknown, options?: Options) {
+  file: string, outputProp: string, expected: unknown, options?: Options) {
   const files = await readFiles([file]);
-  const imOptions = Object.assign({}, {files, isFixedMode: true}, options);
+  const imOptions = Object.assign({}, { files, isFixedMode: true }, options);
   const output = mock(imOptions) as Record<string, {}>;
 
   if (outputProp) {
@@ -50,68 +51,88 @@ async function runTestCase(
 }
 
 async function getOutput(
-    file: string, options?: Options): Promise<Record<string, {}>|string> {
+  file: string, options?: Options): Promise<Record<string, {}> | string> {
   const files = await readFiles([file]);
-  const imOptions = Object.assign({}, {files, isFixedMode: true}, options);
+  const imOptions = Object.assign({}, { files, isFixedMode: true }, options);
   return mock(imOptions) as Record<string, {}>;
 }
 
 describe('Intermock TypeScript: Mock tests', () => {
   it('should generate mock for a flat interface, with just primitives', () => {
     return runTestCase(
-        `${__dirname}/test-data/flat.ts`, 'FlatInterface', expectedFlat);
+      `${__dirname}/test-data/flat.ts`, 'FlatInterface', expectedFlat);
   });
 
   it('should generate mock for a specified mock type', () => {
     return runTestCase(
-        `${__dirname}/test-data/mockType.ts`, 'FlatPerson', expectedMockType);
+      `${__dirname}/test-data/mockType.ts`, 'FlatPerson', expectedMockType);
   });
 
   it('should generate mock for singly nested interfaces', () => {
     return runTestCase(
-        `${__dirname}/test-data/nestedSingle.ts`, 'Person', expectedNested);
+      `${__dirname}/test-data/nestedSingle.ts`, 'Person', expectedNested);
   });
 
   it('should generate mock for interfaces with optional types - optional forced as always',
-     () => {
-       return runTestCase(
-           `${__dirname}/test-data/optional.ts`, 'User',
-           expectedOptional1.User);
-     });
+    () => {
+      return runTestCase(
+        `${__dirname}/test-data/optional.ts`, 'User',
+        expectedOptional1.User);
+    });
 
   it('should generate mock for interfaces with optional types - optional forced as never',
-     () => {
-       return runTestCase(
-           `${__dirname}/test-data/optional.ts`, 'User', expectedOptional2.User,
-           {isOptionalAlwaysEnabled: true});
-     });
+    () => {
+      return runTestCase(
+        `${__dirname}/test-data/optional.ts`, 'User', expectedOptional2.User,
+        { isOptionalAlwaysEnabled: true });
+    });
 
   it('should generate mock for type aliases - as a property', () => {
     return runTestCase(
-        `${__dirname}/test-data/typeAlias.ts`, 'Person',
-        expectedTypeAlias.Person);
+      `${__dirname}/test-data/typeAlias.ts`, 'Person',
+      expectedTypeAlias.Person);
   });
 
   it('should generate mock for type aliases - as a definition', () => {
     return runTestCase(
-        `${__dirname}/test-data/typeAlias.ts`, 'Detail',
-        expectedTypeAlias.Detail);
+      `${__dirname}/test-data/typeAlias.ts`, 'Detail',
+      expectedTypeAlias.Detail);
   });
 
   it('should generate mock for enums', () => {
     return runTestCase(
-        `${__dirname}/test-data/enum.ts`, 'Person', expectedEnum.Person);
+      `${__dirname}/test-data/enum.ts`, 'Person', expectedEnum.Person);
+  });
+
+  it('should generate mock for unions - with generic types', () => {
+    return runTestCase(
+      `${__dirname}/test-data/unions.ts`, 'Account', expectedUnion.Account);
+  });
+
+  it('should generate mock for unions - with type references', () => {
+    return runTestCase(
+      `${__dirname}/test-data/unions.ts`, 'Person', expectedUnion.Person);
+  });
+
+  it('should generate mock for unions - with arrays', () => {
+    return runTestCase(
+      `${__dirname}/test-data/unions.ts`, 'Pack', expectedUnion.Pack);
+  });
+
+  it('should generate mock for unions - for null option to work like question mark', async () => {
+    return runTestCase(
+      `${__dirname}/test-data/unions.ts`, 'LonelyHuman', expectedUnion.LonelyHuman);
   });
 
   it('should generate mock for basic arrays', () => {
     return runTestCase(
-        `${__dirname}/test-data/array.ts`, 'User', expectedArray1.User);
+      `${__dirname}/test-data/array.ts`, 'User', expectedArray1.User);
   });
 
   it('should generate mock for specific interfaces', () => {
     return runTestCase(
-        `${__dirname}/test-data/specificInterfaces.ts`, '',
-        expectedSpecificInterface, {interfaces: ['Person', 'User']});
+      `${__dirname}/test-data/specificInterfaces.ts`, '',
+      expectedSpecificInterface, { interfaces: ['Person', 'User'] });
   });
 
   it('should generate mock for any types', () => {
@@ -121,34 +142,34 @@ describe('Intermock TypeScript: Mock tests', () => {
   it('should generate mock for interfaces with functions', async () => {
     const output = await getOutput(`${__dirname}/test-data/functions.ts`);
     const basicRet =
-        ((output as Record<string, {}>).FunctionInterface as FunctionInterface)
-            .basicFunctionRetNum();
+      ((output as Record<string, {}>).FunctionInterface as FunctionInterface)
+        .basicFunctionRetNum();
     const interfaceRet =
-        ((output as Record<string, {}>).FunctionInterface as FunctionInterface)
-            .functionRetInterface();
+      ((output as Record<string, {}>).FunctionInterface as FunctionInterface)
+        .functionRetInterface();
 
     expect(basicRet).to.eql(86924);
     expect(interfaceRet)
-        .to.eql({name: 'Natasha Jacobs', email: 'Myron_Olson39@hotmail.com'});
+      .to.eql({ name: 'Natasha Jacobs', email: 'Myron_Olson39@hotmail.com' });
   });
 
   it('should generate JSON', async () => {
     const output =
-        await getOutput(`${__dirname}/test-data/json.ts`, {output: 'json'});
+      await getOutput(`${__dirname}/test-data/json.ts`, { output: 'json' });
 
     expect(JSON.parse(output as string))
-        .to.deep.equal(JSON.parse(expectedJson));
+      .to.deep.equal(JSON.parse(expectedJson));
   });
 
   it('should generate extended interfaces', async () => {
     return runTestCase(
-        `${__dirname}/test-data/extension.ts`, 'Contractor',
-        expectedContractor.Contractor);
+      `${__dirname}/test-data/extension.ts`, 'Contractor',
+      expectedContractor.Contractor);
   });
 
   it('should generate mock for namespaced interfaces and enums', () => {
     return runTestCase(
-        `${__dirname}/test-data/namespace.ts`, 'Person',
-        expectedNamespaced.Person);
+      `${__dirname}/test-data/namespace.ts`, 'Person',
+      expectedNamespaced.Person);
   });
 });

--- a/test/ts/test-data/flat.ts
+++ b/test/ts/test-data/flat.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 interface FlatInterface {
+  id: 5,
+  type: 'person',
+  wantsFries: true,
+  wantsChocolate: false,
   name: string;
   age: number;
   isCool: boolean;
@@ -22,5 +26,9 @@ interface FlatInterface {
 export const expectedFlat = {
   name: 'Natasha Jacobs',
   age: 86924,
-  isCool: true
+  isCool: true,
+  type: 'person',
+  id: 5,
+  wantsFries: true,
+  wantsChocolate: false,
 };

--- a/test/ts/test-data/unions.ts
+++ b/test/ts/test-data/unions.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+interface Dog {
+  name: string;
+  owner: string;
+}
+
+interface Cat {
+  name: string;
+  owns: string;
+}
+
+interface Person {
+  name: string;
+  age: number;
+  bestFriend: Dog | Cat;
+}
+
+interface Pack {
+  id: string;
+  dogs: Dog[] | Cat[];
+}
+
+interface Account {
+  id: string;
+  lastDeposit: number | string;
+}
+
+export interface LonelyHuman {
+  name: string;
+  bestFriend: Dog | null;
+}
+
+// TODO: test union with
+// functions: currently I don't know how to make a Union for functions (if the first union option is a function, then the `|` character gets applied to the return type)
+
+export const expectedUnion = {
+  Person: {
+    name: 'Natasha Jacobs',
+    age: 86924,
+    bestFriend: {
+      name: 'Natasha Jacobs',
+      owner: "Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus."
+    }
+  },
+  Pack: {
+    id: "bfc8cb62-c6ce-4194-a2a5-499320b837eb",
+    dogs: [
+      {
+        name: "Natasha Jacobs",
+        owner: "Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus."
+      },
+      {
+        name: "Natasha Jacobs",
+        owner: "Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus."
+      },
+      {
+        name: "Natasha Jacobs",
+        owner: "Animi repellat eveniet eveniet dolores quo ullam rerum reiciendis ipsam. Corrupti voluptatem ipsa illum veritatis eligendi sit autem ut quia. Ea sint voluptas impedit ducimus dolores possimus."
+      }
+    ]
+  },
+  Account: {
+    id: "bfc8cb62-c6ce-4194-a2a5-499320b837eb",
+    lastDeposit: 86924,
+  },
+  LonelyHuman: {
+    name: 'Natasha Jacobs',
+  }
+};


### PR DESCRIPTION
## Purpose
Add support for Unions and Literals' mocking

This is part of a broader feature that intends to include all the most common kinds that apollo codegen generates, so that by using them together we can create graphql mocks